### PR TITLE
we don't actually care about which bundler version to use

### DIFF
--- a/constant_resolver.gemspec
+++ b/constant_resolver.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency("bundler", "~> 2.0.1")
   spec.add_development_dependency("rake", "~> 10.0")
   spec.add_development_dependency("minitest", "~> 5.0")
 end


### PR DESCRIPTION
Trying to fix the deployment; it seems our CI image is using bundler `1.17.2`, but shipit uses bundler `2.0.1` for deploys.

`query_layer` doesn't specify the bundler version and works fine, so we probably shouldn't either.