### PR TITLE
Support the use of a custom inflector

### DIFF
--- a/lib/constant_resolver/version.rb
+++ b/lib/constant_resolver/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ConstantResolver
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/test/fixtures/constant_discovery/valid/app/models/graphql/query_root.rb
+++ b/test/fixtures/constant_discovery/valid/app/models/graphql/query_root.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module GraphQL
+  class QueryRoot
+  end
+end


### PR DESCRIPTION
This PR introduces an injectable inflector for `ConstantResolver`. This allows customizing the inflector with whatever custom inflections an application may have (for example, a customized `ActiveSupport::Inflector`)