### PR TITLE
Make internals private

### DIFF
--- a/lib/constant_resolver.rb
+++ b/lib/constant_resolver.rb
@@ -14,7 +14,7 @@ require "constant_resolver/version"
 #   constant with the same name exists in the inheriting class, and this view is sufficient for all our use cases.
 class ConstantResolver
   class Error < StandardError; end
-  ConstantContext = Struct.new(:name, :location)
+  class ConstantContext < Struct.new(:name, :location); end
 
   class DefaultInflector
     def camelize(string)
@@ -24,6 +24,8 @@ class ConstantResolver
       string
     end
   end
+
+  private_constant :DefaultInflector
 
   # @param root_path [String] The root path of the application to analyze
   # @param load_paths [Array<String>] The autoload paths of the application.
@@ -47,13 +49,6 @@ class ConstantResolver
     @inflector = inflector
   end
 
-  def config
-    {
-      root_path: @root_path,
-      load_paths: @load_paths,
-    }
-  end
-
   # Resolve a constant via its name.
   # If the name is partially qualified, we need the current namespace path to correctly infer its full name
   #
@@ -73,7 +68,9 @@ class ConstantResolver
     )
   end
 
-  # maps constants to file paths
+  # Maps constant names to file paths.
+  #
+  # @return [Hash<String, String>]
   def file_map
     return @file_map if @file_map
     @file_map = {}
@@ -101,6 +98,14 @@ class ConstantResolver
     end
     raise(Error, "could not find any files") if @file_map.empty?
     @file_map
+  end
+
+  # @api private
+  def config
+    {
+      root_path: @root_path,
+      load_paths: @load_paths,
+    }
   end
 
   private

--- a/test/constant_resolver_test.rb
+++ b/test/constant_resolver_test.rb
@@ -2,143 +2,150 @@
 
 require "test_helper"
 
-class ConstantResolverTest < Minitest::Test
-  class OverrideInflector < ConstantResolver::DefaultInflector
-    def initialize(overrides)
-      @overrides = overrides
+class ConstantResolver
+  class ResolveTest < Minitest::Test
+    class OverrideInflector < DefaultInflector
+      def initialize(overrides)
+        @overrides = overrides
+      end
+
+      def camelize(string)
+        string = string.dup
+        @overrides.each do |before, after|
+          string.gsub!(/\b#{before}\b/, after)
+        end
+        super(string)
+      end
     end
 
-    def camelize(string)
-      string = string.dup
-      @overrides.each do |before, after|
-        string.gsub!(/\b#{before}\b/, after)
-      end
-      super(string)
+    def setup
+      @resolver = ConstantResolver.new(
+        root_path: "test/fixtures/constant_discovery/valid/",
+        load_paths: [
+          "app/public",
+          "app/models",
+          "app/models/concerns",
+          "app/services",
+        ],
+        inflector: OverrideInflector.new("graphql" => "GraphQL")
+      )
+      super
     end
-  end
 
-  def setup
-    @resolver = ConstantResolver.new(
-      root_path: "test/fixtures/constant_discovery/valid/",
-      load_paths: [
-        "app/public",
-        "app/models",
-        "app/models/concerns",
-        "app/services",
-      ],
-      inflector: OverrideInflector.new("graphql" => "GraphQL")
-    )
-    super
-  end
-
-  def test_that_it_has_a_version_number
-    refute_nil(::ConstantResolver::VERSION)
-  end
-
-  def test_discovers_simple_constant
-    constant = @resolver.resolve("Order")
-    assert_equal("::Order", constant.name)
-    assert_equal("app/models/order.rb", constant.location)
-  end
-
-  def test_does_not_discover_constant_with_invalid_casing
-    constant = @resolver.resolve("ORDER")
-    assert_nil(constant)
-  end
-
-  def test_understands_nested_load_paths
-    constant = @resolver.resolve("Entry")
-    assert_equal("::Entry", constant.name)
-    assert_equal("app/models/entry.rb", constant.location)
-
-    constant = @resolver.resolve("HasTimeline")
-    assert_equal("::HasTimeline", constant.name)
-    assert_equal("app/models/concerns/has_timeline.rb", constant.location)
-  end
-
-  def test_does_not_try_to_discover_constant_outside_of_load_paths
-    assert(File.file?(@resolver.config[:root_path] + "initializers/app_extensions.rb"))
-
-    constant = @resolver.resolve("AppExtensions")
-    assert_nil(constant)
-  end
-
-  def test_discovers_constants_that_dont_have_their_own_file_using_their_parent_namespace
-    constant = @resolver.resolve(
-      "Sales::Errors::SomethingWentWrong"
-    )
-    assert_equal("::Sales::Errors::SomethingWentWrong", constant.name)
-    assert_equal("app/public/sales/errors.rb", constant.location)
-  end
-
-  def test_discovers_constants_using_custom_inflector
-    constant = @resolver.resolve("GraphQL::QueryRoot")
-
-    assert_equal("::GraphQL::QueryRoot", constant.name)
-    assert_equal("app/models/graphql/query_root.rb", constant.location)
-  end
-
-  def test_discovers_constants_that_are_partially_qualified_inferring_their_full_qualification_from_parent_namespace
-    constant = @resolver.resolve(
-      "Errors",
-      current_namespace_path: ["Sales", "SomeEntrypoint"]
-    )
-    assert_equal("::Sales::Errors", constant.name)
-    assert_equal("app/public/sales/errors.rb", constant.location)
-  end
-
-  def test_discovers_constants_that_are_both_partially_qualified_and_dont_have_their_own_file
-    constant = @resolver.resolve(
-      "Errors::SomethingWentWrong",
-      current_namespace_path: ["Sales", "SomeEntrypoint"]
-    )
-    assert_equal("::Sales::Errors::SomethingWentWrong", constant.name)
-    assert_equal("app/public/sales/errors.rb", constant.location)
-  end
-
-  def test_discovers_constants_that_are_explicitly_toplevel
-    constant = @resolver.resolve("::Order")
-    assert_equal("::Order", constant.name)
-    assert_equal("app/models/order.rb", constant.location)
-  end
-
-  def test_respects_colon_colon_prefix_by_resolving_as_top_level_constant
-    constant = @resolver.resolve(
-      "Entry",
-      current_namespace_path: ["Sales", "SomeEntrypoint"]
-    )
-    assert_equal("::Sales::Entry", constant.name)
-    assert_equal("app/models/sales/entry.rb", constant.location)
-
-    constant = @resolver.resolve(
-      "::Entry",
-      current_namespace_path: ["Sales", "SomeEntrypoint"]
-    )
-    assert_equal("::Entry", constant.name)
-    assert_equal("app/models/entry.rb", constant.location)
-  end
-
-  def test_raises_if_ambiguous_file_path_structure
-    resolver = ConstantResolver.new(@resolver.config.merge(
-      root_path: "test/fixtures/constant_discovery/invalid/"
-    ))
-    begin
-      e = assert_raises(ConstantResolver::Error) do
-        resolver.resolve("AnythingReally")
-      end
-      assert_match("ERROR: 'Order' could refer to any", e.message)
+    def test_that_it_has_a_version_number
+      refute_nil(::ConstantResolver::VERSION)
     end
-  end
 
-  def test_raises_if_no_files
-    resolver = ConstantResolver.new(@resolver.config.merge(
-      root_path: "test/fixtures/constant_discovery/empty/"
-    ))
-    begin
-      e = assert_raises(ConstantResolver::Error) do
-        resolver.resolve("AnythingReally")
+    def test_discovers_simple_constant
+      constant = @resolver.resolve("Order")
+      assert_equal("::Order", constant.name)
+      assert_equal("app/models/order.rb", constant.location)
+    end
+
+    def test_resolve_returns_constant_context
+      context = @resolver.resolve("Order")
+      assert_instance_of(ConstantResolver::ConstantContext, context)
+    end
+
+    def test_does_not_discover_constant_with_invalid_casing
+      constant = @resolver.resolve("ORDER")
+      assert_nil(constant)
+    end
+
+    def test_understands_nested_load_paths
+      constant = @resolver.resolve("Entry")
+      assert_equal("::Entry", constant.name)
+      assert_equal("app/models/entry.rb", constant.location)
+
+      constant = @resolver.resolve("HasTimeline")
+      assert_equal("::HasTimeline", constant.name)
+      assert_equal("app/models/concerns/has_timeline.rb", constant.location)
+    end
+
+    def test_does_not_try_to_discover_constant_outside_of_load_paths
+      assert(File.file?(@resolver.config[:root_path] + "initializers/app_extensions.rb"))
+
+      constant = @resolver.resolve("AppExtensions")
+      assert_nil(constant)
+    end
+
+    def test_discovers_constants_that_dont_have_their_own_file_using_their_parent_namespace
+      constant = @resolver.resolve(
+        "Sales::Errors::SomethingWentWrong"
+      )
+      assert_equal("::Sales::Errors::SomethingWentWrong", constant.name)
+      assert_equal("app/public/sales/errors.rb", constant.location)
+    end
+
+    def test_discovers_constants_using_custom_inflector
+      constant = @resolver.resolve("GraphQL::QueryRoot")
+
+      assert_equal("::GraphQL::QueryRoot", constant.name)
+      assert_equal("app/models/graphql/query_root.rb", constant.location)
+    end
+
+    def test_discovers_constants_that_are_partially_qualified_inferring_their_full_qualification_from_parent_namespace
+      constant = @resolver.resolve(
+        "Errors",
+        current_namespace_path: ["Sales", "SomeEntrypoint"]
+      )
+      assert_equal("::Sales::Errors", constant.name)
+      assert_equal("app/public/sales/errors.rb", constant.location)
+    end
+
+    def test_discovers_constants_that_are_both_partially_qualified_and_dont_have_their_own_file
+      constant = @resolver.resolve(
+        "Errors::SomethingWentWrong",
+        current_namespace_path: ["Sales", "SomeEntrypoint"]
+      )
+      assert_equal("::Sales::Errors::SomethingWentWrong", constant.name)
+      assert_equal("app/public/sales/errors.rb", constant.location)
+    end
+
+    def test_discovers_constants_that_are_explicitly_toplevel
+      constant = @resolver.resolve("::Order")
+      assert_equal("::Order", constant.name)
+      assert_equal("app/models/order.rb", constant.location)
+    end
+
+    def test_respects_colon_colon_prefix_by_resolving_as_top_level_constant
+      constant = @resolver.resolve(
+        "Entry",
+        current_namespace_path: ["Sales", "SomeEntrypoint"]
+      )
+      assert_equal("::Sales::Entry", constant.name)
+      assert_equal("app/models/sales/entry.rb", constant.location)
+
+      constant = @resolver.resolve(
+        "::Entry",
+        current_namespace_path: ["Sales", "SomeEntrypoint"]
+      )
+      assert_equal("::Entry", constant.name)
+      assert_equal("app/models/entry.rb", constant.location)
+    end
+
+    def test_raises_if_ambiguous_file_path_structure
+      resolver = ConstantResolver.new(@resolver.config.merge(
+        root_path: "test/fixtures/constant_discovery/invalid/"
+      ))
+      begin
+        e = assert_raises(ConstantResolver::Error) do
+          resolver.resolve("AnythingReally")
+        end
+        assert_match("ERROR: 'Order' could refer to any", e.message)
       end
-      assert_match("could not find any files", e.message)
+    end
+
+    def test_raises_if_no_files
+      resolver = ConstantResolver.new(@resolver.config.merge(
+        root_path: "test/fixtures/constant_discovery/empty/"
+      ))
+      begin
+        e = assert_raises(ConstantResolver::Error) do
+          resolver.resolve("AnythingReally")
+        end
+        assert_match("could not find any files", e.message)
+      end
     end
   end
 end


### PR DESCRIPTION
Mark `ConstantResolver#config` as private API, also make `ConstantResolver::DefaultInflector` a private constant.