### PR TITLE
Remove error raising on no files in map

### DIFF
--- a/lib/constant_resolver.rb
+++ b/lib/constant_resolver.rb
@@ -96,7 +96,6 @@ class ConstantResolver
       end.join("\n")
       raise(Error, message)
     end
-    raise(Error, "could not find any files") if @file_map.empty?
     @file_map
   end
 

--- a/test/constant_resolver_test.rb
+++ b/test/constant_resolver_test.rb
@@ -135,17 +135,5 @@ class ConstantResolver
         assert_match("ERROR: 'Order' could refer to any", e.message)
       end
     end
-
-    def test_raises_if_no_files
-      resolver = ConstantResolver.new(@resolver.config.merge(
-        root_path: "test/fixtures/constant_discovery/empty/"
-      ))
-      begin
-        e = assert_raises(ConstantResolver::Error) do
-          resolver.resolve("AnythingReally")
-        end
-        assert_match("could not find any files", e.message)
-      end
-    end
   end
 end


### PR DESCRIPTION
If there are no files in the file map, why are raising an error? I could be misunderstanding, but I don't see the point of doing this.