### PR TITLE
Add ci_url to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -4,3 +4,4 @@ owners:
 - Shopify/component-patterns
 slack_channels:
 - architecture-patterns
+ci_url: https://github.com/Shopify/constant_resolver/actions?query=workflow%3ACI


### PR DESCRIPTION
Set this repo's continuous integration url in service.yml to fix a failing Services DB check.

Link to: https://github.com/Shopify/constant_resolver/actions?query=workflow%3ACI