### PR TITLE
Change slack channel to core-stewardship

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,4 +1,4 @@
 classification: library
 slack_channels:
-- architecture-patterns
+- core-stewardship
 ci_url: https://github.com/Shopify/constant_resolver/actions?query=workflow%3ACI


### PR DESCRIPTION
We're deleting the architecture-patterns channel, so I'm moving updating the channel to the correct one.