### PR TITLE
use Module.const_source_location to resolve constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Ruby 2.6
+      - name: Set up Ruby 2.7
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.7.x
       - name: Run tests
         run: |
           gem install bundler
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Ruby 2.6
+      - name: Set up Ruby 2.7
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.7.x
       - name: Run style checks
         run: |
           gem install bundler

--- a/constant_resolver.gemspec
+++ b/constant_resolver.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
+  spec.add_dependency("activesupport")
+
   spec.add_development_dependency("rake", "~> 10.0")
   spec.add_development_dependency("minitest", "~> 5.0")
 end

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: constant-resolver
 type: ruby
 
 up:
-  - ruby: 2.6.2
+  - ruby: 2.7.2
   - bundler
 
 commands:

--- a/test/constant_resolver_test.rb
+++ b/test/constant_resolver_test.rb
@@ -19,8 +19,10 @@ class ConstantResolver
     end
 
     def setup
+      fixture_root_path = "test/fixtures/constant_discovery/valid/"
+      Dir[File.join(fixture_root_path, "**/*.rb")].each { |f| require File.expand_path(f) }
       @resolver = ConstantResolver.new(
-        root_path: "test/fixtures/constant_discovery/valid/",
+        root_path: fixture_root_path,
         load_paths: [
           "app/public",
           "app/models",


### PR DESCRIPTION
If we could use `Module.const_source_location` to resolve constants,

- we'd have a first step towards analyzing code that is not zeitwerk-loaded (yay gems!)
- we wouldn't have to know about custom inflections to resolve constants

Sadly, as this PR demonstrates, `Module.const_source_location` returns the first definition (according to load order) of a constant only, and that isn't always the correct one.
