### PR TITLE
Default namespace support

### DIFF
--- a/lib/constant_resolver.rb
+++ b/lib/constant_resolver.rb
@@ -123,7 +123,7 @@ class ConstantResolver
     load_paths = Hash[load_paths.map { |p| [p, "Object"] }] unless load_paths.respond_to?(:transform_keys)
 
     load_paths.transform_keys! { |p| p.end_with?("/") ? p : p + "/" }
-    load_paths.transform_values! { |ns| ns.delete_prefix("::") }
+    load_paths.transform_values! { |ns| ns.to_s.delete_prefix("::") }
 
     load_paths
   end

--- a/test/constant_resolver_test.rb
+++ b/test/constant_resolver_test.rb
@@ -43,11 +43,14 @@ class ConstantResolver
     end
 
     def test_resolves_constants_from_non_default_root_path_namespace
+      Object.const_set(:Api, Module.new)
+
       resolver = ConstantResolver.new(
         root_path: "test/fixtures/constant_discovery/valid/",
         load_paths: {
-          "app/models" => "::Object",
-          "app/rest_api" => "::Api",
+          "app/models" => Object,
+          "app/rest_api" => Api,
+          "app/internal" => "::Company::Internal",
         },
       )
 
@@ -58,6 +61,10 @@ class ConstantResolver
       constant = resolver.resolve("Api::Repositories")
       assert_equal("::Api::Repositories", constant.name)
       assert_equal("app/rest_api/repositories.rb", constant.location)
+
+      constant = resolver.resolve("Company::Internal::Main")
+      assert_equal("::Company::Internal::Main", constant.name)
+      assert_equal("app/internal/main.rb", constant.location)
     end
 
     def test_resolve_returns_constant_context

--- a/test/constant_resolver_test.rb
+++ b/test/constant_resolver_test.rb
@@ -42,6 +42,24 @@ class ConstantResolver
       assert_equal("app/models/order.rb", constant.location)
     end
 
+    def test_resolves_constants_from_non_default_root_path_namespace
+      resolver = ConstantResolver.new(
+        root_path: "test/fixtures/constant_discovery/valid/",
+        load_paths: {
+          "app/models" => "::Object",
+          "app/rest_api" => "::Api",
+        },
+      )
+
+      constant = resolver.resolve("Order")
+      assert_equal("::Order", constant.name)
+      assert_equal("app/models/order.rb", constant.location)
+
+      constant = resolver.resolve("Api::Repositories")
+      assert_equal("::Api::Repositories", constant.name)
+      assert_equal("app/rest_api/repositories.rb", constant.location)
+    end
+
     def test_resolve_returns_constant_context
       context = @resolver.resolve("Order")
       assert_instance_of(ConstantResolver::ConstantContext, context)

--- a/test/fixtures/constant_discovery/valid/app/internal/main.rb
+++ b/test/fixtures/constant_discovery/valid/app/internal/main.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Company
+  module Internal
+    class Main
+    end
+  end
+end

--- a/test/fixtures/constant_discovery/valid/app/rest_api/repositories.rb
+++ b/test/fixtures/constant_discovery/valid/app/rest_api/repositories.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Api
+  class Repositories
+  end
+end


### PR DESCRIPTION
As described in https://github.com/Shopify/packwerk/issues/186, Zeitwerk supports default modules for root directories. This pull request adds support for this capability to `ConstantResolver`.

I opted to keep this as simple as possible and just deal with Strings for the constant names. The resolver appears to inherently only be concerned with Strings anyway so it seemed to be consistent to me versus holding references to `Module` instances. If the provided load paths hash points to modules, as it does in the hash returned by `Zeitwerk::Loader#root_dirs`, then we just call `to_s` on them anyway.

For detecting whether the load paths are a hash or not, I duck check to see if the argument responds to `:transform_keys`. I'm not sure if this is ideal, maybe others have ideas?

I've also tested this change in concert with the Packwerk changes on [this branch](https://github.com/Shopify/packwerk/compare/main...github:load-paths-hash) against the GitHub monolith to ensure things behave as expected. The GitHub monolith is old and has a few root directories which have default namespaces other than `Object` so this is a decent test case. I'm pleased to report the expected violations were detected resulting much more accurate reports.

cc @exterm @rafaelfranca from our discussions on https://github.com/Shopify/packwerk/issues/186