### PR TITLE
Exclude load paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ context.name     # => "::Some::Nested::Model"
 context.location # => "models/some/nested/model.rb"
 ```
 
+### Ignoring paths
+
+You may want to only resolve constants from certain sections of your application. If you want to leave any paths out, use `exclude`:
+
+```ruby
+resolver = ConstantResolver.new(
+  root_path: "/app",
+  load_paths: [
+    "/app/models",
+    "/some/engine/app/models",
+  ],
+  exclude: [
+    "some/engine/**/*"
+  ],
+)
+```
+
 ## Development
 
 After checking out the repo, run `bundle` to install dependencies. Then, run `rake test` to run the tests.

--- a/test/constant_resolver_test.rb
+++ b/test/constant_resolver_test.rb
@@ -197,5 +197,14 @@ class ConstantResolver
         MSG
       end
     end
+
+    def test_respects_exclude
+      resolver = ConstantResolver.new(**@resolver.config.merge(
+        exclude: ["app/models/**/*"],
+      ))
+
+      constant = resolver.resolve("Order")
+      assert_nil(constant)
+    end
   end
 end


### PR DESCRIPTION
Allow load path exclusion so that certain paths should be ignored. This is useful to ignore engines separate to a main application that live within your application.